### PR TITLE
Added missing kubectl cluster-info command to cdk-aws and cdk-azure

### DIFF
--- a/cdk-aws/README.md
+++ b/cdk-aws/README.md
@@ -190,6 +190,8 @@ Next we copy over the configuration file:
 Finally, using kubectl we can check that kubernetes cluster interaction is possible:
 
 ```
+  kubectl cluster-info
+
 Kubernetes master is running at https://34.253.164.197:443
 
 Heapster is running at https://34.253.164.197:443/api/v1/namespaces/kube-system/services/heapster/proxy

--- a/cdk-azure/README.md
+++ b/cdk-azure/README.md
@@ -152,6 +152,8 @@ Next we copy over the configuration file:
 Finally, using kubectl we can check that kubernetes cluster interaction is possible:
 
 ```
+ kubectl cluster-info
+
 Kubernetes master is running at https://34.253.164.197:443
 
 Heapster is running at https://34.253.164.197:443/api/v1/namespaces/kube-system/services/heapster/proxy


### PR DESCRIPTION
I added the missing "kubectl cluster-info" command to cdk-aws and cdk-azure